### PR TITLE
Tweak tab theming

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -5,18 +5,13 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<link rel="stylesheet" type="text/css" href="/styles/base.scss">
 		<link rel="icon" href="/assets/favicon.ico" type="image/x-icon">
-		
-		<!-- I don't know what this does. An LLM gave it to me and it seems to reduce the stutter when loading the font. Or maybe it's the first step of its plan to take over the world? -->
-		<link rel="preload" href="https://fonts.googleapis.com/css2?family=Asap:wght@400;500;700&family=Noto+Sans:wght@400;700&display=swap" as="style" onload="this.rel='stylesheet'">
-		<noscript>
-			<link href="https://fonts.googleapis.com/css2?family=Asap:wght@400;500;700&family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
-		</noscript>
+		<link href="https://fonts.googleapis.com/css2?family=Asap:wght@400;500;700&family=Noto+Sans:wght@400;700&display=swap" rel="stylesheet">
 	
 		<!-- Title -->
 		{% if title | length == 0 %}
 			<title>GodSVG</title>
 		{% else %}
-			<title>{{ title }} - GodSVG</title>
+			<title>{{ title }}</title>
 		{% endif %}
 
 		{% include "metadata.njk" %}

--- a/src/index.html
+++ b/src/index.html
@@ -1,3 +1,6 @@
+---
+title: GodSVG - SVG Editor
+---
 {% extends "base.njk" %}
 
 {% block head %}
@@ -153,7 +156,7 @@
 					<img class="social-icon" src="/assets/socials_twitter.png" alt="Twitter icon" loading="lazy">
 					<a href="https://twitter.com/MewPurPur">tweeter account</a> for hot takes I'll regret later.
 				</li>
-				<!-- YouTube is way too irrelevant, there's nothing GodSVG-related on it right now. I was thinking about tool tutorials, but not at the moment.
+				<!-- Yuutub is way too irrelevant, there's nothing GodSVG-related on it right now. I was thinking about tool tutorials, but not at the moment.
 				<li>
 					<img class="social-icon" src="/assets/socials_youtube.png" alt="YouTube icon" loading="lazy">
 					<a href="https://www.youtube.com/@MewPurPur">yuutub channel</a> for Like, comment, and subscribe!

--- a/src/releases.html
+++ b/src/releases.html
@@ -1,5 +1,5 @@
 ---
-title: Releases
+title: Releases - GodSVG
 ---
 {% extends "base.njk" %}
 

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -86,7 +86,7 @@ br {
 .tab-container {
 	display: flex;
 	justify-content: center;
-	margin: 20px 0;
+	margin-top: 30px;
 	gap: 20px;
 
 	.tab {
@@ -103,14 +103,15 @@ br {
 }
 
 .tab {
-	flex: 1; /* Ensure tabs are equal width */
+	flex: 1; // Ensure tabs are equal width.
+	font-size: 0.9rem;
 	display: inline-block;
 	background-color: #333;
 	color: #e0e0e0;
 	padding: 10px 20px;
 	border-radius: 5px;
 	cursor: pointer;
-	text-align: center; /* Center the text inside the tabs */
+	text-align: center; // Center the text inside the tabs.
 
 	&:hover {
 		color: #f4f4f4;


### PR DESCRIPTION
More space above, slightly smaller font size (I think it looks better, and should be relevant on mobile). Also changes titles to not be restricted to the "{title} - GodSVG" format. Removes the old font preload hack that was supposedly counterproductive.