### PR TITLE
Add Atom RSS feed

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,5 @@
 import { HtmlBasePlugin, InputPathToUrlTransformPlugin } from "@11ty/eleventy";
+import pluginRss from "@11ty/eleventy-plugin-rss";
 import path from "node:path";
 import * as sass from "sass";
 import markdownIt from "markdown-it";
@@ -24,6 +25,7 @@ export default async function(eleventyConfig) {
 	// Plugins
 	eleventyConfig.addPlugin(HtmlBasePlugin);
 	eleventyConfig.addPlugin(InputPathToUrlTransformPlugin);
+	eleventyConfig.addPlugin(pluginRss);
 
 	// Filters & Shortcodes
 	eleventyConfig.addAsyncFilter("pageExists", async function(url) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
+				"@11ty/eleventy-plugin-rss": "^2.0.4",
 				"html-minifier-terser": "^7.2.0",
 				"markdown-it": "^14.1.0",
 				"sass": "^1.87.0"
@@ -175,6 +176,35 @@
 				"url": "https://opencollective.com/11ty"
 			}
 		},
+		"node_modules/@11ty/eleventy-plugin-rss": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-rss/-/eleventy-plugin-rss-2.0.4.tgz",
+			"integrity": "sha512-LF60sGVlxGTryQe3hTifuzrwF8R7XbrNsM2xfcDcNMSliLN4kmB+7zvoLRySRx0AQDjqhPTAeeeT0ra6/9zHUQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@11ty/eleventy-utils": "^2.0.0",
+				"@11ty/posthtml-urls": "^1.0.1",
+				"debug": "^4.4.0",
+				"posthtml": "^0.16.6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/11ty"
+			}
+		},
+		"node_modules/@11ty/eleventy-plugin-rss/node_modules/@11ty/eleventy-utils": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-2.0.7.tgz",
+			"integrity": "sha512-6QE+duqSQ0GY9rENXYb4iPR4AYGdrFpqnmi59tFp9VrleOl0QSh8VlBr2yd6dlhkdtj7904poZW5PvGr9cMiJQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/11ty"
+			}
+		},
 		"node_modules/@11ty/eleventy-utils": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.3.tgz",
@@ -210,7 +240,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@11ty/posthtml-urls/-/posthtml-urls-1.0.1.tgz",
 			"integrity": "sha512-6EFN/yYSxC/OzYXpq4gXDyDMlX/W+2MgCvvoxf11X1z76bqkqFJ8eep5RiBWfGT5j0323a1pwpelcJJdR46MCw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"evaluate-value": "^2.0.0",
@@ -1023,7 +1052,6 @@
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
 			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "^2.1.3"
@@ -1074,7 +1102,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
 			"integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"domelementtype": "^2.0.1",
@@ -1089,7 +1116,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
 			"integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
@@ -1099,7 +1125,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
 			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -1112,7 +1137,6 @@
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
 			"integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"domelementtype": "^2.2.0"
@@ -1128,7 +1152,6 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
 			"integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"dom-serializer": "^1.0.1",
@@ -1264,7 +1287,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/evaluate-value/-/evaluate-value-2.0.0.tgz",
 			"integrity": "sha512-VonfiuDJc0z4sOO7W0Pd130VLsXN6vmBWZlrog1mCb/o7o/Nl5Lr25+Kj/nkCCAhG+zqeeGjxhkK9oHpkgTHhQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -1555,7 +1577,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
 			"integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
-			"dev": true,
 			"funding": [
 				"https://github.com/fb55/htmlparser2?sponsor=1",
 				{
@@ -1575,7 +1596,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
 			"integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
-			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=0.12"
@@ -1588,7 +1608,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-2.0.1.tgz",
 			"integrity": "sha512-XJpDL/MLkV3dKwLzHwr2dY05dYNfBNlyPu4STQ8WvKCFdc6vC5tPXuq28of663+gHVg03C+16pHHs/+FmmDjcw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
@@ -1721,7 +1740,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
 			"integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/is-number": {
@@ -1844,7 +1862,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
 			"integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lower-case": {
@@ -2051,7 +2068,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/no-case": {
@@ -2163,7 +2179,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
 			"integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/parseurl": {
@@ -2250,7 +2265,6 @@
 			"version": "0.16.6",
 			"resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.6.tgz",
 			"integrity": "sha512-JcEmHlyLK/o0uGAlj65vgg+7LIms0xKXe60lcDOTU7oVX/3LuEuLwrQpW3VJ7de5TaFKiW4kWkaIpJL42FEgxQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"posthtml-parser": "^0.11.0",
@@ -2277,7 +2291,6 @@
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
 			"integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"htmlparser2": "^7.1.1"
@@ -2290,7 +2303,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
 			"integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-json": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
 		"@11ty/eleventy": "^3.0.0"
 	},
 	"dependencies": {
+		"@11ty/eleventy-plugin-rss": "^2.0.4",
 		"html-minifier-terser": "^7.2.0",
 		"markdown-it": "^14.1.0",
 		"sass": "^1.87.0"

--- a/src/_includes/article.njk
+++ b/src/_includes/article.njk
@@ -1,7 +1,7 @@
 ---
 permalink: "article/{{ slugcat | slugify }}/index.html"
 prerelease: false
-date:
+date: Created
 ---
 {% extends "base.njk" %}
 
@@ -16,7 +16,7 @@ date:
         <img src="/assets/blog/{{slugcat | slugify}}/cover.webp" class="article-cover"/>
         <h1 class="article-title">{{ title }}</h1>
         <div class="article-metadata">
-            <span class="article-author">By: MewPurPur</span>
+            <span class="article-author">By: {{page.author}}</span>
             <span class="article-date" title="{{page.date.toUTCString()}}">
                 {{page.date.toLocaleString("en-us", { year:"numeric", month:"short", day:"numeric" })}}
             </span>

--- a/src/articles/1.0-alpha1/article.md
+++ b/src/articles/1.0-alpha1/article.md
@@ -1,6 +1,8 @@
 ---
 slugcat: 1.0-alpha1
 title: GodSVG's first development build is out!
+tagline:
+author: MewPurPur
 tags: release
 date: Created
 release: 1.0-alpha1

--- a/src/articles/1.0-alpha2/article.md
+++ b/src/articles/1.0-alpha2/article.md
@@ -1,13 +1,13 @@
 ---
 slugcat: 1.0-alpha2
 title: "New prerelease: GodSVG 1.0-alpha2"
+tagline: GodSVG is out for web and MacOS!
+author: MewPurPur
 tags: release
 date: Created
 release: 1.0-alpha2
 prerelease: true
 ---
-
-Tagline: GodSVG is out for web and MacOS!
 
 It has only been two weeks since the first development build of GodSVG, but thanks to open-source contributions, there are already enough new things for a new alpha build.
 

--- a/src/articles/articles.11tydata.js
+++ b/src/articles/articles.11tydata.js
@@ -1,6 +1,6 @@
 export default {
     layout: "article.njk",
-    tags: "article",
+    tags: "articles",
 	permalink: function ({ slugcat }) {
 		return `/article/${this.slugify(slugcat)}/index.html`;
 	},

--- a/src/blog-rss.html
+++ b/src/blog-rss.html
@@ -1,0 +1,24 @@
+---
+permalink: /blog/rss.xml
+---
+<?xml version="1.0" encoding="utf-8"?>
+<!-- https://www.rfc-editor.org/rfc/rfc4287.html -->
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>GodSVG Blog</title>
+    <link>https://www.godsvg.com</link>
+    <description>News about GodSVG releases and more</description>
+    
+    {% for post in collections.articles %}
+        <entry>
+            <title>{{post.data.title}}</title>
+            <link href="/article/{{post.data.slugcat | slugify}}" />
+            <author>{{post.data.author}}</author>
+            <published>{{post.date | dateToRfc3339}}</published>
+            <summary>{{post.data.tagline}}</summary>
+            <id>{{post.data.slugcat | slugify}}</id>
+            <content type="html" xml:lang="en">
+                {{ post.content | safe }}
+            </content>
+        </entry>
+    {% endfor %}
+</feed>

--- a/src/blog.html
+++ b/src/blog.html
@@ -14,6 +14,7 @@ title: Blog - GodSVG
                 <a href="/article/{{post.data.slugcat | slugify}}">
                     <img src="/assets/blog/{{post.data.slugcat | slugify}}/cover.webp" class="blog-thumbnail" alt="{{post.data.title}}"/>
                     <p>{{post.data.title}}</p>
+                    <p>{{post.data.tagline}}</p>
                 </a>
             </div>
         {% endfor %}

--- a/src/blog.html
+++ b/src/blog.html
@@ -9,7 +9,7 @@ title: Blog - GodSVG
 
 {% block body %}
     <div class="blog-posts-grid">
-        {% for post in collections.article %}
+        {% for post in collections.articles %}
             <div class="blog-card">
                 <a href="/article/{{post.data.slugcat | slugify}}">
                     <img src="/assets/blog/{{post.data.slugcat | slugify}}/cover.webp" class="blog-thumbnail" alt="{{post.data.title}}"/>


### PR DESCRIPTION
Adds a very basic RSS feed using the [Atom feed specifications](https://www.rfc-editor.org/rfc/rfc4287.html)

The current implementation should preferably be touched up in further PRs, but it does work for now.

The feed is located at `/blog/rss.xml` currently.
Technically, this should be called something like `feed.xml` since Atom isn't RSS, but most RSS readers are compatible with Atom as its the replacement to RSS and most people call Atom 'RSS' regardless.
