### PR TITLE
Fix article downloads buttons showing the wrong platforms, and styling

### DIFF
--- a/src/_data/downloads.js
+++ b/src/_data/downloads.js
@@ -1,18 +1,29 @@
+import fs from "node:fs"
+import path from "node:path"
+
 // Release download link generator
 
 export default function(configData) {
     return function(version=null) {
         if (version == null) version = configData.godsvg.version;
-        if (version != "latest") {
-            version = "v" + version;
-        }
-        const base = `https://github.com/MewPurPur/GodSVG/releases/download/${version}`;
-        
-        return {
-            android: `${base}/GodSVG.Android.apk`,
+        const base = `https://github.com/MewPurPur/GodSVG/releases/download/${version != "latest" ? "v"+version : version}`;
+        const platformToDownload = {
+            android: `${base}/GodSVG.Android.zip`,
             linux:   `${base}/GodSVG.Linux.zip`,
             macos:   `${base}/GodSVG.MacOS.zip`,
             windows: `${base}/GodSVG.Windows.zip`
         }
+
+        // Reading release data
+        const releasesPath = path.join(configData.eleventy.directories.data, "releases.json")
+        const releasesFile = fs.readFileSync(releasesPath, { encoding: "utf-8" });
+        const releasesJson = JSON.parse(releasesFile)[version];
+
+        // Creating the object
+        const output = {}
+        releasesJson.platforms.forEach(platform => {
+            output[platform] = platformToDownload[platform];
+        });
+        return output;
     }
 }

--- a/src/_includes/article.njk
+++ b/src/_includes/article.njk
@@ -7,7 +7,7 @@ date: Created
 
 {% block style %}
 	<link rel="stylesheet" type="text/css" href="/styles/article.scss">
-	<link rel="stylesheet" type="text/css" href="/templates/donation_widget.scss">
+	<link rel="stylesheet" type="text/css" href="/styles/includes/downloads.scss">
 {% endblock %}
 
 {% block body %}
@@ -43,8 +43,14 @@ date: Created
 					{% endif %}
 					<div style="margin: 1rem">
 						{% include "data/downloads.njk" %}
-						{% for key, platform in downloads(release) %}
-							<a href="{{platform}}" style="display: block">Download for {{key | capitalize}}</a>
+						{% for platform, release in downloads(release) %}
+							<div style="display: block">
+								<img src="/assets/platforms_{{platform}}.svg" alt="_" class="solo-platform-icon">
+								<span>{{platformInfo.displayNames[platform]}}</span>
+								<a href="{{release}}" class="btn btn-download release-download" version="{{release}}">
+									<span id="dropbtn-text">Download</span>
+								</a>
+							</div>
 						{% endfor %}
 					</div>
 				</div>

--- a/src/styles/includes/downloads.scss
+++ b/src/styles/includes/downloads.scss
@@ -12,11 +12,6 @@
 	margin-right: 10px;
 }
 
-.dropdown {
-	position: relative;
-	display: inline-block;
-}
-
 .btn-download {
 	background-color: #2e6cb8;
 	color: #fff;
@@ -186,6 +181,77 @@
 	&:last-child {
 		border-bottom-left-radius: 6px;
 		border-bottom-right-radius: 6px;
+	}
+}
+
+.btn {
+	padding: 0.3rem 0.5rem;
+	border-radius: 5px;
+	font-family: $title_font;
+	font-weight: 500;
+	font-size: 0.75rem;
+	cursor: pointer;
+	user-select: none;
+	text-decoration: none !important;
+	text-align: center;
+	display: inline-block;
+	min-width: 0;
+	&:hover {
+		color: white;
+	}
+}
+
+.btn-notes {
+	background-color: color.adjust($background, $lightness: 15%);
+	color: #fff;
+	&:hover {
+		color: #fff;
+		background-color: color.adjust($background, $lightness: 20%);
+	}
+}
+
+.dropdown {
+	position: relative;
+	display: inline-block;
+}
+
+@media (max-width: 720px) {
+	.release-box {
+		flex-direction: column;
+		align-items: flex-start;
+		padding: 15px;
+	}
+
+	.release-actions {
+		gap: 0.25rem;
+	}
+
+	.release-info {
+		flex-direction: row;
+		align-items: center;
+		width: 100%;
+		justify-content: space-between;
+		margin-bottom: 0.5rem;
+	}
+
+	.release-date {
+		margin-top: 0;
+		margin-right: 0.3rem;
+	}
+
+	.release-actions {
+		width: 100%;
+		justify-content: space-evenly;
+	}
+
+	.btn, .btn-download {
+		justify-content: center;
+	}
+
+	.dropdown-content {
+		width: 100%;
+		left: 0;
+		right: auto;
 	}
 }
 

--- a/src/styles/releases.scss
+++ b/src/styles/releases.scss
@@ -1,5 +1,6 @@
 @use "sass:color";
 @use "scss/theme" as *;
+@use "includes/downloads" as *;
 
 .container {
 	width: 92.5%;
@@ -60,74 +61,4 @@
 	display: flex;
 	gap: 1rem;
 	align-items: center;
-}
-
-.btn {
-	padding: 0.3rem 0.5rem;
-	border-radius: 5px;
-	font-family: $title_font;
-	font-weight: 500;
-	font-size: 0.75rem;
-	cursor: pointer;
-	text-decoration: none !important;
-	text-align: center;
-	display: inline-block;
-	min-width: 0;
-	&:hover {
-		color: white;
-	}
-}
-
-.btn-notes {
-	background-color: color.adjust($background, $lightness: 15%);
-	color: #fff;
-	&:hover {
-		color: #fff;
-		background-color: color.adjust($background, $lightness: 20%);
-	}
-}
-
-.dropdown {
-	position: relative;
-	display: inline-block;
-}
-
-@media (max-width: 720px) {
-	.release-box {
-		flex-direction: column;
-		align-items: flex-start;
-		padding: 15px;
-	}
-
-	.release-actions {
-		gap: 0.25rem;
-	}
-
-	.release-info {
-		flex-direction: row;
-		align-items: center;
-		width: 100%;
-		justify-content: space-between;
-		margin-bottom: 0.5rem;
-	}
-
-	.release-date {
-		margin-top: 0;
-		margin-right: 0.3rem;
-	}
-
-	.release-actions {
-		width: 100%;
-		justify-content: space-evenly;
-	}
-
-	.btn, .btn-download {
-		justify-content: center;
-	}
-
-	.dropdown-content {
-		width: 100%;
-		left: 0;
-		right: auto;
-	}
 }


### PR DESCRIPTION
Previously, buttons on articles looked like hyperlinks, and did not take platforms into account _(ex: would show an Android download button on alpha1, which did not contain an Android release)_

![image](https://github.com/user-attachments/assets/f3b1a262-7a6e-49e1-bb72-7de52a413c40)

Not the best looking still but I despise writing css myself, so additional css tweaks would be welcome