### PR TITLE
Update package.json license

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"keywords": [],
 	"author": "",
-	"license": "ISC",
+	"license": "MIT",
 	"type": "module",
 	"devDependencies": {
 		"@11ty/eleventy": "^3.0.0"


### PR DESCRIPTION
`package.json` license didn't match the license file