### PR TITLE
Fix social media card sizing

### DIFF
--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -38,8 +38,8 @@
 			<meta property="twitter:url" content="{{ site.url }}" />
 			<meta property="twitter:title" content="{{ metaTitle }}" />
 			<meta property="twitter:description" content="{{ metaDescription }}" />
-			<meta property="twitter:card" content="{{ site.url }}/assets/card.webp" />
 			<meta property="twitter:image" content="{{ site.url }}/assets/card.webp" />
+			<meta property="twitter:card" content="summary_large_image" />
 		{% endblock %}
 
 		{% block head %}{% endblock %}


### PR DESCRIPTION
Card currently looks too small
<img src="https://github.com/user-attachments/assets/88e275a8-5068-4a5d-92e3-90616b55193d" alt="_" width="500px" />

Should hopefully look more like this now:
<img src="https://github.com/user-attachments/assets/e1b512b2-5af9-4a2f-93ab-88b5bc2ddf1a" alt="_" width="500px" />

Can't test it, but platforms like Discord seem to use Tweeter metadata.
I've looked at other websites and the `twitter:card` property was supposed to have a value stating the size of the cover image, not the cover image itself.