### PR TITLE
Move padding units to rem

### DIFF
--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -2,7 +2,7 @@
 @use "scss/theme" as *;
 
 $max-width: 960px;
-$padding-size: min(1.65rem, 2rem);
+$padding-size: min(1.65rem, 4vw);
 $content-width: min($max-width, calc(100% - $padding-size * 2));
 
 .article-header {

--- a/src/styles/article.scss
+++ b/src/styles/article.scss
@@ -2,7 +2,7 @@
 @use "scss/theme" as *;
 
 $max-width: 960px;
-$padding-size: min(1.65rem, 4vw);
+$padding-size: min(1.65rem, 2rem);
 $content-width: min($max-width, calc(100% - $padding-size * 2));
 
 .article-header {
@@ -118,7 +118,7 @@ $content-width: min($max-width, calc(100% - $padding-size * 2));
 	gap: 1.25rem;
 	background-color: color.adjust($background, $lightness: +2%);
 	border-radius: 5px;
-	padding: 16px 22px;
+	padding: 1rem 1.3rem;
 }
 
 .support-panel-paragraph {

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -239,7 +239,7 @@ li {
 	position: absolute;
 	top: 50%;
 	transform: translateY(-50%);
-	padding: 16px 12px;
+	padding: 1rem 0.8rem;
 	background-color: rgba(0, 0, 0, 0.6);
 	border: none;
 	cursor: pointer;
@@ -272,7 +272,7 @@ li {
 	gap: 8px;
 	pointer-events: auto;
 	background-color: rgba(0, 0, 0, 0.5);
-	padding: 10px 15px;
+	padding: 0.5rem 0.9rem;
 	border-radius: 15px;
 }
 

--- a/src/styles/includes/downloads.scss
+++ b/src/styles/includes/downloads.scss
@@ -46,7 +46,7 @@
 
 	a {
 		color: white;
-		padding: 10px 12px;
+		padding: 0.6rem 0.7rem;
 		text-decoration: none !important;
 		display: flex;
 		align-items: center;

--- a/src/styles/includes/downloads.scss
+++ b/src/styles/includes/downloads.scss
@@ -57,7 +57,7 @@
 		}
 
 		.platform-icon {
-			margin-right: 10px;
+			margin-right: 0.6rem;
 			height: 2.5rem;
 			width: 2.5rem;
 		}
@@ -77,7 +77,7 @@
 		}
 
 		.solo-platform-icon {
-			margin-right: 8px;
+			margin-right: 0.5rem;
 			height: 2rem;
 			width: 2rem;
 		}

--- a/src/styles/includes/notices.scss
+++ b/src/styles/includes/notices.scss
@@ -1,6 +1,6 @@
 .notice-panel {
 	position: relative;
-	padding: 38px 20px 16px 16px;
+	padding: 2.1rem 1.1rem 0.9rem 0.9rem;
 	border-radius: 6px;
 
 	&.info {
@@ -35,7 +35,7 @@
 		position: absolute;
 		top: -2px;
 		left: -2px;
-		padding: 2px 10px;
+		padding: 0.1rem 0.5rem;
 		border-bottom-right-radius: 6px;
 		border-top-left-radius: 8px; // Bigger than 6 to avoid anti-aliasing overlaps.
 	}

--- a/src/styles/releases.scss
+++ b/src/styles/releases.scss
@@ -57,7 +57,7 @@
 	.release-box {
 		flex-direction: column;
 		align-items: flex-start;
-		padding: 1rem;
+		padding: 0.8rem;
 	}
 
 	.release-info {

--- a/src/styles/releases.scss
+++ b/src/styles/releases.scss
@@ -57,7 +57,7 @@
 	.release-box {
 		flex-direction: column;
 		align-items: flex-start;
-		padding: 15px;
+		padding: 1rem;
 	}
 
 	.release-info {

--- a/src/styles/templates/donation_widget.scss
+++ b/src/styles/templates/donation_widget.scss
@@ -16,7 +16,7 @@ $con-color: #e99;
 	margin-top: 0.4rem;
 	font-size: 0.9rem;
 	position: relative;
-	min-width: 280px;
+	min-width: 15.5rem;
 	padding: 1.5rem 1.1rem 0.8rem;
 	border: 2px solid $frame-border;
 	border-radius: 6px;
@@ -47,7 +47,7 @@ $con-color: #e99;
 .donation-buttons {
 	display: flex;
 	justify-content: center;
-	gap: 1.4rem;
+	gap: 1.3rem;
 	margin: 0.2rem;
 }
 

--- a/src/styles/templates/donation_widget.scss
+++ b/src/styles/templates/donation_widget.scss
@@ -17,7 +17,7 @@ $con-color: #e99;
 	font-size: 0.9rem;
 	position: relative;
 	min-width: 280px;
-	padding: 1.4rem 1.1rem 0.9rem;
+	padding: 1.5rem 1.1rem 0.8rem;
 	border: 2px solid $frame-border;
 	border-radius: 6px;
 	background-color: transparent;
@@ -32,14 +32,14 @@ $con-color: #e99;
 .donation-header {
 	color: $text-color;
 	font-weight: 700;
-	font-size: 14px;
+	font-size: 0.8rem;
 	white-space: nowrap;
 	position: absolute;
 	top: -12px;
 	left: 50%;
 	transform: translateX(-50%);
 	background-color: $tab-bg;
-	padding: 0 0.4rem 0.2rem 0.4rem;
+	padding: 0 0.4rem 0.1rem 0.4rem;
 	border: 2px solid $frame-border;
 	border-radius: 4px;
 }
@@ -47,13 +47,13 @@ $con-color: #e99;
 .donation-buttons {
 	display: flex;
 	justify-content: center;
-	gap: 24px;
-	margin: 5px;
+	gap: 1.4rem;
+	margin: 0.2rem;
 }
 
 .donation-button {
-	width: 64px;
-	height: 64px;
+	width: 3.55rem;
+	height: 3.55rem;
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -72,17 +72,17 @@ $con-color: #e99;
 	}
 
 	& .donation-platform-icon {
-		width: 40px;
-		height: 40px;
+		width: 2.2rem;
+		height: 2.2rem;
 		margin: 0;
 	}
 }
 
 .platform-details-container {
-	padding-top: 8px;
-	border-top: 1px solid $frame-border;
-	margin-top: 16px;
-	min-height: 96px;
+	padding-top: 0.5rem;
+	border-top: 0.1rem solid $frame-border;
+	margin-top: 0.9rem;
+	min-height: 5.2rem;
 }
 
 .platform-details {
@@ -91,15 +91,15 @@ $con-color: #e99;
 
 .platform-name {
 	font-weight: bold;
-	margin-bottom: 8px;
+	margin-bottom: 0.5rem;
 }
 
 .list-pro {
 	color: $pro-color;
-	margin-bottom: 4px;
+	margin-bottom: 0.2rem;
 	font-size: 0.9rem;
 	line-height: 1.15 !important;
-	padding-left: 6px;
+	padding-left: 0.4rem;
 
 	&::before {
 		content: "+";
@@ -111,10 +111,10 @@ $con-color: #e99;
 
 .list-con {
 	color: $con-color;
-	margin-bottom: 4px;
+	margin-bottom: 0.3rem;
 	font-size: 0.9rem;
 	line-height: 1.15 !important;
-	padding-left: 6px;
+	padding-left: 0.4rem;
 
 	&::before {
 		content: "–";
@@ -127,5 +127,5 @@ $con-color: #e99;
 .hover-info {
 	color: $dim-text;
 	text-align: center;
-	margin-top: 8px;
+	margin-top: 0.45rem;
 }

--- a/src/styles/templates/donation_widget.scss
+++ b/src/styles/templates/donation_widget.scss
@@ -17,7 +17,7 @@ $con-color: #e99;
 	font-size: 0.9rem;
 	position: relative;
 	min-width: 280px;
-	padding: 24px 20px 16px;
+	padding: 1.4rem 1.1rem 0.9rem;
 	border: 2px solid $frame-border;
 	border-radius: 6px;
 	background-color: transparent;
@@ -27,7 +27,6 @@ $con-color: #e99;
 		padding: 0;
 		list-style: none;
 	}
-
 }
 
 .donation-header {
@@ -40,7 +39,7 @@ $con-color: #e99;
 	left: 50%;
 	transform: translateX(-50%);
 	background-color: $tab-bg;
-	padding: 0px 8px 3px 8px;
+	padding: 0 0.4rem 0.2rem 0.4rem;
 	border: 2px solid $frame-border;
 	border-radius: 4px;
 }


### PR DESCRIPTION
I've moved all the padding units to use `rem` instead of `px`.
<img src="https://media1.tenor.com/m/a1V-3ctKdQ0AAAAC/rem-rezero.gif" alt="'rem'.. get it?" width="100px" />

All the fonts already used `rem`.
Not sure how this improves mobile things specifically but I've done as suggested in DMs.
I got things _mostly_ pixel-perfect during migration.

