### PR TITLE
Fix Atom feed id/author and improve feed discovery

### DIFF
--- a/src/blog-atom.xml.njk
+++ b/src/blog-atom.xml.njk
@@ -1,26 +1,38 @@
 ---
-# Specification: https://www.rfc-editor.org/rfc/rfc4287.html
 permalink: /blog/atom.xml
 ---
+{#-
+	Specification: https://www.rfc-editor.org/rfc/rfc4287.html
+	Documentation: https://validator.w3.org/feed/docs/atom.html
+
+	NOTE: Any instance of "godsvg.com" over {{site.url}} here is deliberate,
+	we CANNOT risk IDs changing as it breaks links for all RSS readers.
+-#}
 <?xml version="1.0" encoding="utf-8"?>
-<feed xmlns="http://www.w3.org/2005/Atom">
+<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
 	<title>GodSVG Blog</title>
-	<description>News about GodSVG releases and more</description>
-	<link rel="alternate" type="text/html" href="{{ site.url }}" hreflang="en" />
+	<subtitle>News about GodSVG releases and more</subtitle>
+	<link rel="alternate" type="text/html" href="{{ site.url }}" />
 	<link rel="self" type="application/atom+xml" href="{{ site.url }}{{ permalink }}" />
+	<id>https://godsvg.com/</id>
+	<updated>{{ collections["articles"] | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
+	<author><name>MewPurPur</name></author>
+	<contributor><name>FlooferLand</name></contributor>
 
 	{%- for post in collections.articles | reverse %}
+	{%- set postSlug = (post.data.slugcat | slugify) %}
 	<entry>
 		<title>{{post.data.title}}</title>
 		<summary>{{post.data.tagline}}</summary>
-		<author>{{post.data.author}}</author>
-		<published>{{post.date | dateToRfc3339}}</published>
-		<id>{{post.data.slugcat | slugify}}</id>
-		<link href="/article/{{post.data.slugcat | slugify}}" />
-		<content type="html" xml:lang="en"> <![CDATA[
-			<link rel="stylesheet" type="text/css" href="{{site.url}}/styles/article.css" />
-			{{- post.content | safe | indent(12) -}}
-		]]> </content>
+		<author><name>{{post.data.author}}</name></author>
+		<published>{{ post.date | dateToRfc3339 }}</published>
+		<updated>{{ post.date | dateToRfc3339 }}</updated>
+		<id>tag:godsvg.com,{{post.date.getFullYear()}}:{{post.data.slugcat | slugify}}</id>
+		<link href="/article/{{postSlug}}" />
+		<link rel="enclosure" type="image/webp" href="{{ site.url }}/assets/blog/{{postSlug}}/cover.webp" />
+		<content type="html">
+			{{ post.content | renderTransforms(post.data.page, metadata.base) }}
+		</content>
 	</entry>
 	{%- endfor %}
 </feed>

--- a/src/blog.html
+++ b/src/blog.html
@@ -4,7 +4,7 @@ title: Blog - GodSVG
 {% extends "base.njk" %}
 
 {% block head %}
-	<link rel="alternate" type="application/atom+xml" title="GodSVG Blog" href="/blog/feed.xml" />
+	<link rel="alternate" type="application/atom+xml" title="GodSVG Blog" href="{{site.url}}/blog/feed.xml" />
 {% endblock %}
 
 {% block style %}


### PR DESCRIPTION
Previously, the author would show up as undefined/unknown.
https://validator.w3.org/feed was also unable to find feeds.
I've also tweaked some additional things, which should make the feed better over-all

**NOTE:** This PR also changes IDs to use the more standardized `tag:` format, which will break the feed for anyone who is currently subscribed to it.
I think its worth it as not many people have subscribed so far, and its better to have a standardized ID system than not.