### PR TITLE
Fix RSS feed button and feed browser styling

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -27,7 +27,6 @@ export default async function(eleventyConfig) {
 	// Plugins
 	eleventyConfig.addPlugin(HtmlBasePlugin);
 	eleventyConfig.addPlugin(InputPathToUrlTransformPlugin);
-	eleventyConfig.addPlugin(pluginRss);
 
 	// Filters & Shortcodes
 	eleventyConfig.addAsyncFilter("pageExists", async function(url) {
@@ -156,6 +155,19 @@ export default async function(eleventyConfig) {
 		// Strip any leading "@".
 		const clean = username.replace(/^@/, "");
 		return `<a href="https://github.com/${clean}" target="_blank" rel="noopener noreferrer">${clean}</a>`;
+	});
+
+	// XML / RSS things
+	eleventyConfig.addPlugin(pluginRss);
+	eleventyConfig.addTemplateFormats("xsl");
+	eleventyConfig.addWatchTarget("**/*.xsl");
+	eleventyConfig.addExtension("xsl", {
+		outputFileExtension: "xsl",
+		compile: function (inputContent, inputPath) {
+			return function (data) {
+				return inputContent;
+			};
+		},
 	});
 
 	// Minifying on release (https://github.com/terser/html-minifier-terser?tab=readme-ov-file#options-quick-reference)

--- a/src/blog-atom.xml.njk
+++ b/src/blog-atom.xml.njk
@@ -9,6 +9,7 @@ permalink: /blog/atom.xml
 	we CANNOT risk IDs changing as it breaks links for all RSS readers.
 -#}
 <?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="/styles/blog.xsl"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en">
 	<title>GodSVG Blog</title>
 	<subtitle>News about GodSVG releases and more</subtitle>
@@ -28,7 +29,7 @@ permalink: /blog/atom.xml
 		<published>{{ post.date | dateToRfc3339 }}</published>
 		<updated>{{ post.date | dateToRfc3339 }}</updated>
 		<id>tag:godsvg.com,{{post.date.getFullYear()}}:{{post.data.slugcat | slugify}}</id>
-		<link href="/article/{{postSlug}}" />
+		<link rel="alternate" href="/article/{{postSlug}}" />
 		<link rel="enclosure" type="image/webp" href="{{ site.url }}/assets/blog/{{postSlug}}/cover.webp" />
 		<content type="html">
 			{{ post.content | renderTransforms(post.data.page, metadata.base) }}

--- a/src/blog.html
+++ b/src/blog.html
@@ -15,7 +15,7 @@ title: Blog - GodSVG
 	<div class="content-container">
 		<div class="page-title">
 			GodSVG Blog
-			<a href="/blog/atom.xml" id="blog-feed-btn"><img src="/assets/feed.svg" />ATOM</a>
+			<a href="/blog/atom.xml" id="blog-feed-btn" title="ATOM feed for ATOM/RSS feed readers"><img src="/assets/feed.svg"/></a>
 		</div>
 		<div class="blog-posts-grid">
 			{% for post in collections.articles | reverse %}

--- a/src/styles/blog.scss
+++ b/src/styles/blog.scss
@@ -87,43 +87,30 @@
 }
 
 #blog-feed-btn {
-	$bg: #e67a21;
-	$text: #fff;
+	$bg: #d06915;
 	$size: 1rem;
-	$max-width: 480px;
 
 	position: absolute;
 	margin-left: 1rem;
 	background-color: $bg;
-	color: $text;
 
-	padding: 0.2rem 0.35rem;
+	padding: 0.2rem 0.2rem;
 	border-radius: 5px;
 	cursor: pointer;
 	user-select: none;
 	text-decoration: none !important;
-	text-align: center;
-	font-size: $size;
-	@media (max-width: $max-width) {
-		font-size: $size * 0.7;
-	}
 
 	display: inline-flex;
 	align-items: start;
 	gap: 4px;
 
 	&:hover {
-		color: color.adjust($text, $lightness: 10%);
-		background-color: color.adjust($bg, $lightness: 10%);
+		background-color: color.adjust($bg, $lightness: -5%);
 	}
 
 	img {
 		margin: auto;
 		width: $size;
 		height: $size;
-		@media (max-width: $max-width) {
-			width: $size * 0.7;
-			height: $size * 0.7;
-		}
 	}
 }

--- a/src/styles/blog.xsl
+++ b/src/styles/blog.xsl
@@ -1,0 +1,91 @@
+<xsl:stylesheet
+    version="1.0"
+	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:atom="http://www.w3.org/2005/Atom"
+    exclude-result-prefixes="atom"
+>
+	<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+	<xsl:template match="/">
+        <html xmlns="http://www.w3.org/1999/xhtml">
+            <head>
+                <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+                <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+                <title>Web Feed • <xsl:value-of select="atom:feed/atom:title"/></title>
+                <link rel="stylesheet" type="text/css" href="/styles/blog.xsl.css"></link>
+            </head>
+            <body>
+                <section class="alert">
+                    <p><strong>This is a web feed</strong>, also known as an RSS feed.</p>
+                    <p><strong>Subscribe</strong> by copying the address bar URL into your feed reader.</p>
+                    <a target="_blank">
+                        <xsl:attribute name="href">
+                            <xsl:value-of select="atom:link[@rel='self']/@href"/>
+                        </xsl:attribute>
+                        <xsl:value-of select="atom:link[@rel='self']/@href"/>
+                    </a>
+                </section>
+                <section>
+                    <xsl:apply-templates select="atom:feed" />
+                </section>
+                <section>
+                    <h2>Recent entries</h2>
+                    <xsl:apply-templates select="atom:feed/atom:entry" />
+                </section>
+            </body>
+        </html>
+    </xsl:template>
+
+    <!-- Feed preview info -->
+    <xsl:template match="atom:feed">
+        <h1>
+            <xsl:value-of select="atom:title"/> - Web Feed Preview
+        </h1>
+        <p>This RSS feed provides the latest posts from the <xsl:value-of select="atom:title"/></p>
+        <a class="head_link" target="_blank" href="https://godsvg.com">
+            Back to website &#x2192;
+        </a>
+        <h2>What is a web feed?</h2>
+        <p>
+            A web feed, or alternatively called an RSS feed, is a data format that users can plug into some feed readers <i>(or some browsers)</i> in order to get notifications when new posts are available.
+        </p>    
+        <ul>
+            <li>
+                <strong>Light-weight</strong>. There is no CSS styling or any fancy rendering required when using RSS feeds.
+            </li>
+            <li>
+                <strong>View everything</strong>. Unlike mailing lists, past entries will always be available to you.
+            </li>
+            <li>
+                <strong>Privacy-first</strong>. While we do no data-collecting, ads, or any fancy JavaScript framework wizardry,
+                other websites do collect your data and web feeds are a great way to read blogs while avoiding them doing so, as feeds only download XML files and never send anything away from your device.
+            </li>
+        </ul>
+        
+        <!--
+            Leaving this for GodSVG 2, when we inevitably get bought out by Microsoft - FlooferLand
+         -->
+        <!--p>
+            We use JavaScript and collect private user information on https://godsvg.com industries, so this is a great alternative to viewing our posts for the odd viewers that don't wish us to send their Real Name, Phone Number, Email Address, Public IP Address, and more identifiable information to our partners.
+        </p-->
+    </xsl:template>
+
+    <!-- Tiny blog post previews -->
+    <xsl:template match="atom:entry">
+        <div class="entry">
+            <h3>
+                <a target="_blank">
+                    <xsl:attribute name="href">
+                        <xsl:value-of select="atom:link[@rel='alternate']/@href"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="atom:title"/>
+                </a>
+            </h3>
+            <p>
+                <xsl:value-of select="atom:summary" disable-output-escaping="yes" />
+            </p>
+            <small>
+                Published: <xsl:value-of select="atom:updated" />
+            </small>
+        </div>
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/styles/blog.xsl
+++ b/src/styles/blog.xsl
@@ -1,91 +1,91 @@
 <xsl:stylesheet
-    version="1.0"
+	version="1.0"
 	xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:atom="http://www.w3.org/2005/Atom"
-    exclude-result-prefixes="atom"
+	exclude-result-prefixes="atom"
 >
 	<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
 	<xsl:template match="/">
-        <html xmlns="http://www.w3.org/1999/xhtml">
-            <head>
-                <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-                <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
-                <title>Web Feed • <xsl:value-of select="atom:feed/atom:title"/></title>
-                <link rel="stylesheet" type="text/css" href="/styles/blog.xsl.css"></link>
-            </head>
-            <body>
-                <section class="alert">
-                    <p><strong>This is a web feed</strong>, also known as an RSS feed.</p>
-                    <p><strong>Subscribe</strong> by copying the address bar URL into your feed reader.</p>
-                    <a target="_blank">
-                        <xsl:attribute name="href">
-                            <xsl:value-of select="atom:link[@rel='self']/@href"/>
-                        </xsl:attribute>
-                        <xsl:value-of select="atom:link[@rel='self']/@href"/>
-                    </a>
-                </section>
-                <section>
-                    <xsl:apply-templates select="atom:feed" />
-                </section>
-                <section>
-                    <h2>Recent entries</h2>
-                    <xsl:apply-templates select="atom:feed/atom:entry" />
-                </section>
-            </body>
-        </html>
-    </xsl:template>
+		<html xmlns="http://www.w3.org/1999/xhtml">
+			<head>
+				<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+				<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1"/>
+				<title>Web Feed • <xsl:value-of select="atom:feed/atom:title"/></title>
+				<link rel="stylesheet" type="text/css" href="/styles/blog.xsl.css"></link>
+			</head>
+			<body>
+				<section class="alert">
+					<p><strong>This is a web feed</strong>, also known as an RSS feed.</p>
+					<p><strong>Subscribe</strong> by copying the address bar URL into your feed reader.</p>
+					<a target="_blank">
+						<xsl:attribute name="href">
+							<xsl:value-of select="atom:link[@rel='self']/@href"/>
+						</xsl:attribute>
+						<xsl:value-of select="atom:link[@rel='self']/@href"/>
+					</a>
+				</section>
+				<section>
+					<xsl:apply-templates select="atom:feed" />
+				</section>
+				<section>
+					<h2>Recent entries</h2>
+					<xsl:apply-templates select="atom:feed/atom:entry" />
+				</section>
+			</body>
+		</html>
+	</xsl:template>
 
-    <!-- Feed preview info -->
-    <xsl:template match="atom:feed">
-        <h1>
-            <xsl:value-of select="atom:title"/> - Web Feed Preview
-        </h1>
-        <p>This RSS feed provides the latest posts from the <xsl:value-of select="atom:title"/></p>
-        <a class="head_link" target="_blank" href="https://godsvg.com">
-            Back to website &#x2192;
-        </a>
-        <h2>What is a web feed?</h2>
-        <p>
-            A web feed, or alternatively called an RSS feed, is a data format that users can plug into some feed readers <i>(or some browsers)</i> in order to get notifications when new posts are available.
-        </p>    
-        <ul>
-            <li>
-                <strong>Light-weight</strong>. There is no CSS styling or any fancy rendering required when using RSS feeds.
-            </li>
-            <li>
-                <strong>View everything</strong>. Unlike mailing lists, past entries will always be available to you.
-            </li>
-            <li>
-                <strong>Privacy-first</strong>. While we do no data-collecting, ads, or any fancy JavaScript framework wizardry,
-                other websites do collect your data and web feeds are a great way to read blogs while avoiding them doing so, as feeds only download XML files and never send anything away from your device.
-            </li>
-        </ul>
-        
-        <!--
-            Leaving this for GodSVG 2, when we inevitably get bought out by Microsoft - FlooferLand
-         -->
-        <!--p>
-            We use JavaScript and collect private user information on https://godsvg.com industries, so this is a great alternative to viewing our posts for the odd viewers that don't wish us to send their Real Name, Phone Number, Email Address, Public IP Address, and more identifiable information to our partners.
-        </p-->
-    </xsl:template>
+	<!-- Feed preview info -->
+	<xsl:template match="atom:feed">
+		<h1>
+			<xsl:value-of select="atom:title"/> - Web Feed Preview
+		</h1>
+		<p>This RSS feed provides the latest posts from the <xsl:value-of select="atom:title"/></p>
+		<a class="head_link" target="_blank" href="https://godsvg.com">
+			Back to website &#x2192;
+		</a>
+		<h2>What is a web feed?</h2>
+		<p>
+			A web feed, or alternatively called an RSS feed, is a data format that users can plug into some feed readers <i>(or some browsers)</i> in order to get notifications when new posts are available.
+		</p>    
+		<ul>
+			<li>
+				<strong>Lightweight</strong>. There is no CSS styling or any fancy rendering required when using RSS feeds.
+			</li>
+			<li>
+				<strong>View everything</strong>. Unlike mailing lists, past entries will always be available to you.
+			</li>
+			<li>
+				<strong>Privacy-first</strong>. While we do no data-collecting, ads, or any fancy JavaScript framework wizardry,
+				other websites do collect your data and web feeds are a great way to read blogs while avoiding them doing so, as feeds only download XML files and never send anything away from your device.
+			</li>
+		</ul>
+		
+		<!--
+			Leaving this for GodSVG 2, when we inevitably get bought out by Microsoft - FlooferLand
+		 -->
+		<!--p>
+			We use JavaScript and collect private user information on https://godsvg.com industries, so this is a great alternative to viewing our posts for the odd viewers that don't wish us to send their Real Name, Phone Number, Email Address, Public IP Address, and more identifiable information to our partners.
+		</p-->
+	</xsl:template>
 
-    <!-- Tiny blog post previews -->
-    <xsl:template match="atom:entry">
-        <div class="entry">
-            <h3>
-                <a target="_blank">
-                    <xsl:attribute name="href">
-                        <xsl:value-of select="atom:link[@rel='alternate']/@href"/>
-                    </xsl:attribute>
-                    <xsl:value-of select="atom:title"/>
-                </a>
-            </h3>
-            <p>
-                <xsl:value-of select="atom:summary" disable-output-escaping="yes" />
-            </p>
-            <small>
-                Published: <xsl:value-of select="atom:updated" />
-            </small>
-        </div>
-    </xsl:template>
+	<!-- Tiny blog post previews -->
+	<xsl:template match="atom:entry">
+		<div class="entry">
+			<h3>
+				<a target="_blank">
+					<xsl:attribute name="href">
+						<xsl:value-of select="atom:link[@rel='alternate']/@href"/>
+					</xsl:attribute>
+					<xsl:value-of select="atom:title"/>
+				</a>
+			</h3>
+			<p>
+				<xsl:value-of select="atom:summary" disable-output-escaping="yes" />
+			</p>
+			<small>
+				Published: <xsl:value-of select="atom:updated" />
+			</small>
+		</div>
+	</xsl:template>
 </xsl:stylesheet>

--- a/src/styles/blog.xsl.scss
+++ b/src/styles/blog.xsl.scss
@@ -1,0 +1,47 @@
+body {
+    max-width: 50rem;
+    margin: 0 auto;
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 1.2rem;
+    line-height: 1.5rem;
+}
+
+section {
+    margin: 30px 15px;
+}
+
+h1 {
+    font-size: 2em;
+    margin: .67em 0;
+    line-height: 1.125em;
+}
+
+h2 {
+    border-bottom: 1px solid #eaecef;
+    padding-bottom: .3em;
+}
+
+.alert {
+    background: #fff5b1;
+    padding: 4px 12px;
+    margin: 0 -12px;
+}
+
+a {
+    text-decoration: none;
+    &, &:visited, &:hover, &:active {
+        color: rgb(0, 145, 255);
+    }
+}
+
+li {
+    margin-bottom: 1rem;
+}
+
+.entry h3 {
+    margin-bottom: 0;
+}
+
+.entry p {
+    margin: 4px 0;
+}


### PR DESCRIPTION
This PR removes the "ATOM" text, making the feed button smaller and less intrusive, while adding a tooltip to show extra information.

This also adds an optional XML stylesheet for the feed, that only web browsers will grab.
Making feeds generally more user-friendly, as it won't display a massive raw XML file to users who have a browser with no RSS/ATOM feed support
