### PR TITLE
Add external metadata to blog articles

### DIFF
--- a/src/_includes/article.njk
+++ b/src/_includes/article.njk
@@ -5,13 +5,21 @@ date: Created
 ---
 {% extends "base.njk" %}
 
+{% block metadata %}
+	{% from "macros.njk" import metadata with context %}
+	{{ metadata(
+		title=title,
+		description=tagline,
+		cover=site.url + "/assets/blog/" + (slugcat | slugify) + "/cover.webp")
+	}}
+{% endblock %}
+
 {% block style %}
 	<link rel="stylesheet" type="text/css" href="/styles/article.scss">
 	<link rel="stylesheet" type="text/css" href="/styles/includes/downloads.scss">
 {% endblock %}
 
 {% block body %}
-
 	<div class="article-header">
 		<img src="/assets/blog/{{slugcat | slugify}}/cover.webp" class="article-cover"/>
 		<h2 class="article-title">{{ title }}</h2>

--- a/src/_includes/base.njk
+++ b/src/_includes/base.njk
@@ -15,31 +15,8 @@
 		{% endif %}
 
 		{% block metadata %}
-			{% set metaTitle = (metaTitle or title or "GodSVG - Free and Open Source SVG editor") %}
-			{% set metaDescription = (metaDescription or "A free, open-source, low-level vector graphics editor, available on all major desktop platforms and on web.") %}
-
-			<!-- Primary meta tags -->
-			<meta name="title" content="{{ metaTitle }}" />
-			<meta name="description" content="{{ metaDescription }}" />
-			<meta content="#489ae0" data-react-helmet="true" name="theme-color" />
-
-			<!-- Open Graph -->
-			<meta property="og:image" content="{{ site.url }}/assets/card.webp" />
-			<meta property="og:type" content="website" />
-			<meta property="og:url" content="{{ site.url }}" />
-			<meta property="og:title" content="{{ metaTitle }}" />
-			<meta property="og:description" content="{{ metaDescription }}" />
-			<meta property="og:icon" content="{{ site.url }}/assets/favicon.ico" />
-			<meta property="og:type" content="website" />
-			<meta property="og:locale" content="en_US" />
-			<meta property="og:site_name" content="GodSVG" />
-
-			<!-- Tweeter -->
-			<meta property="twitter:url" content="{{ site.url }}" />
-			<meta property="twitter:title" content="{{ metaTitle }}" />
-			<meta property="twitter:description" content="{{ metaDescription }}" />
-			<meta property="twitter:image" content="{{ site.url }}/assets/card.webp" />
-			<meta property="twitter:card" content="summary_large_image" />
+			{% from "macros.njk" import metadata with context %}
+			{{ metadata() }}
 		{% endblock %}
 
 		{% block head %}{% endblock %}

--- a/src/_includes/macros.njk
+++ b/src/_includes/macros.njk
@@ -1,0 +1,29 @@
+<!-- Page metadata -->
+{% macro metadata(
+    title=(metaTitle or title or "GodSVG - Free and Open Source SVG editor"),
+    description=(metaDescription or "A free, open-source, low-level vector graphics editor, available on all major desktop platforms and on web."),
+    cover=(site.url + "/assets/card.webp")
+) %}
+    <!-- Primary meta tags -->
+    <meta name="title" content="{{ title }}" />
+    <meta name="description" content="{{ description }}" />
+    <meta content="#489ae0" data-react-helmet="true" name="theme-color" />
+
+    <!-- Open Graph -->
+    <meta property="og:image" content="{{cover}}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="{{ site.url }}" />
+    <meta property="og:title" content="{{ title }}" />
+    <meta property="og:description" content="{{ description }}" />
+    <meta property="og:icon" content="{{ site.url }}/assets/favicon.ico" />
+    <meta property="og:type" content="website" />
+    <meta property="og:locale" content="en_US" />
+    <meta property="og:site_name" content="GodSVG" />
+
+    <!-- Tweeter -->
+    <meta property="twitter:url" content="{{ site.url }}" />
+    <meta property="twitter:title" content="{{ title }}" />
+    <meta property="twitter:description" content="{{ description }}" />
+    <meta property="twitter:image" content="{{cover}}" />
+    <meta property="twitter:card" content="summary_large_image" />    
+{% endmacro %}


### PR DESCRIPTION
This implements metadata for to make embeds on other platforms (Discord, Tweeter, etc) pick up information about blog articles. I've also added a macro that allows you to easily change the metadata per page.

Embeds should now look something like the ones for Godot's blog posts:
![image](https://github.com/user-attachments/assets/b4af0f97-3ac5-42ef-9b97-1685b70062b9)
